### PR TITLE
Hh and hm merge

### DIFF
--- a/Step01 - DHS to VCQI Conversion Steps.do
+++ b/Step01 - DHS to VCQI Conversion Steps.do
@@ -15,7 +15,13 @@ Stata version:    14.0
 * Date 			number 	Name			What Changed
 * 2016-10-12			Dale			Change hid to hhid in line 162
 *										(Thanks to David Brown)
-
+* 2018-05-30			MK Trimner		Changed the merge to exclude hhid and include respondent 
+*										id for both Household and household member datasets
+*										when RI datasets are used. 
+*										Also removed line to rename caseid to hhid as 
+*										it is no longer used 
+*										Note: Have not completed this change for TT only
+*										surveys as need to confirm the variables. 
 ********************************************************************************
 
 * Create one large dataset
@@ -99,7 +105,7 @@ if $RI_SURVEY ==1 & $TT_SURVEY==1 {
 	append using not_unique
 
 	* Merge in Household data
-	merge m:1 hhid $STRATUM_ID $HH_ID $CLUSTER_ID using "${DHS_HR_DATA}" 
+	merge m:1 $STRATUM_ID $HH_ID $CLUSTER_ID using "${DHS_HR_DATA}" 
 
 	keep if _merge == 1 | _merge == 3
 	
@@ -162,9 +168,6 @@ if $RI_SURVEY ==1 & $TT_SURVEY!=1 {
 	sort $STRATUM_ID $CLUSTER_ID $HH_ID h$RESPONDENT_LINE $HM_LINE
 	bysort $STRATUM_ID $CLUSTER_ID $HH_ID h$RESPONDENT_LINE $HM_LINE: gen linecount=_N
 	
-	* Rename caseid so it can be merged with Household members and Household list datasets
-	rename caseid hhid
-
 	preserve
 	keep if linecount > 1
 	save not_unique, replace
@@ -172,7 +175,7 @@ if $RI_SURVEY ==1 & $TT_SURVEY!=1 {
 	keep if linecount == 1
 	
 	* Merge in Household Member data
-	merge 1:1 hhid $STRATUM_ID $HH_ID $CLUSTER_ID $HM_LINE using "${DHS_PR_DATA}"
+	merge 1:1 $STRATUM_ID $CLUSTER_ID $HH_ID h$RESPONDENT_LINE $HM_LINE using "${DHS_PR_DATA}"
 	
 	keep if _merge == 1 | _merge == 3
 
@@ -183,7 +186,7 @@ if $RI_SURVEY ==1 & $TT_SURVEY!=1 {
 	save, replace
 
 	* Merge in Household data
-	merge m:1 hhid $STRATUM_ID $HH_ID $CLUSTER_ID h$RESPONDENT_LINE using "${DHS_HR_DATA}" //Merge with HM
+	merge m:1 $STRATUM_ID $HH_ID $CLUSTER_ID h$RESPONDENT_LINE using "${DHS_HR_DATA}" //Merge with HM
 
 	keep if _merge == 1 | _merge == 3
 	

--- a/Step02 - DHS to VCQI Conversion Steps.do
+++ b/Step02 - DHS to VCQI Conversion Steps.do
@@ -14,7 +14,7 @@ Stata version:    14.0
 * Date 			number 	Name			What Changed
 * 2016-10-12			Dale			Added CHILD_IS_ALIVE and 
 *										CHILD_BORN_ALIVE to varlist
-* 2018-05-30			MK Trimne		added global CHILD_SEX for RI dataset
+* 2018-05-30			MK Trimner		added global CHILD_SEX for RI dataset
 *										as optional input
 ********************************************************************************
 

--- a/Step02 - DHS to VCQI Conversion Steps.do
+++ b/Step02 - DHS to VCQI Conversion Steps.do
@@ -14,7 +14,8 @@ Stata version:    14.0
 * Date 			number 	Name			What Changed
 * 2016-10-12			Dale			Added CHILD_IS_ALIVE and 
 *										CHILD_BORN_ALIVE to varlist
-
+* 2018-05-30			MK Trimne		added global CHILD_SEX for RI dataset
+*										as optional input
 ********************************************************************************
 
 * The below globals are required for all DHS to VCQI Conversion
@@ -88,7 +89,7 @@ foreach v in STRATUM_ID STRATUM_NAME CLUSTER_ID CLUSTER_NAME HH_ID HH_DATE_MONTH
 * These variables are not required in the surveys but if populated need to verify the variable exists
  foreach v in DATE_OF_BIRTH_MONTH DATE_OF_BIRTH_YEAR DATE_OF_BIRTH_DAY AGE_YEARS DATE_OF_BIRTH AGE_MONTHS ///
 				CHILD_AGE_MONTHS CHILD_AGE_YEARS CHILD_DOB_CARD_MONTH CHILD_DOB_CARD_DAY CHILD_DOB_CARD_YEAR LEVEL_4_ID ///
-				MOTHER_DOB_DAY MOTHER_AGE_YEARS TT_LAST_BIRTH_MONTHS LAST_TT_MONTH LAST_TT_YEAR CHILD_IS_ALIVE CHILD_BORN_ALIVE BCG_SCAR {
+				MOTHER_DOB_DAY MOTHER_AGE_YEARS TT_LAST_BIRTH_MONTHS LAST_TT_MONTH LAST_TT_YEAR CHILD_IS_ALIVE CHILD_BORN_ALIVE BCG_SCAR CHILD_SEX {
 			if "$`v'"!="" {
 			capture confirm variable ${`v'}
 				if !_rc {

--- a/Step03 - DHS to VCQI Conversion Steps.do
+++ b/Step03 - DHS to VCQI Conversion Steps.do
@@ -15,6 +15,7 @@ Stata version:    14.0
 * 2016-10-12			Dale			Fixed typo when SIA is off
 * 2016-10-12			Dale			Do NOT use mother's DOB for eligibility
 *										if they did a TT survey
+* 20108-05-30			MK Trimner		Added child sex to RI dataset from Child dataset
 
 ********************************************************************************
 
@@ -560,7 +561,14 @@ if $RI_SURVEY==1 {
 	label value RI27 card_seen
 	
 	* Create RI20 Sex
-	clonevar RI20=HM27
+	if "${CHILD_SEX}"!="" {
+		clonevar RI20=${CHILD_SEX}
+	
+		replace RI20=HM27 if missing(RI20)
+	}
+	else {
+		clonevar RI20=HM27
+	}
 
 	**********************************************************************************
 	*Create dob for child history and card register if RIHC records sought

--- a/VCQI CONVERSION PROGRAM AND GLOBAL MACRO LIST.do
+++ b/VCQI CONVERSION PROGRAM AND GLOBAL MACRO LIST.do
@@ -172,6 +172,9 @@ global CHILD_AGE_MONTHS			hw1		// OPTIONAL -can be blank if not available
 * Is the child alive?
 global CHILD_IS_ALIVE			b5  // make this 1 if there is no variable in the dataset
 
+* Sex of child
+global CHILD_SEX				b4
+
 * Provide a complete list of the RI doses, use the same dose names as the globals below
 * all dose numbers must be provided, so if there are three doses provide the dose1 dose2 dose3.
 


### PR DESCRIPTION
These errors were discovered in the Ethiopian 2000, 2005, 2011 and 2016 analysis that the HH and HM datasets were blank due to merging issues. Identified that one variable being used was no longer consistent across each dataset and removed it from the merge and added respondent id. 